### PR TITLE
fix borrower_timetable index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.7.1
+-------------------------
+
+- fix `index` for `borrower_timetable` method that did not take into account starting index of `lender_timetables`
+
 v0.7.0
 -------------------------
 

--- a/lib/loan_creator/borrower_timetable.rb
+++ b/lib/loan_creator/borrower_timetable.rb
@@ -7,6 +7,8 @@ module LoanCreator
       :period_capital,
       :total_paid_capital_end_of_period,
       :total_paid_interests_end_of_period,
+      :capitalized_interests_beginning_of_period,
+      :capitalized_interests_end_of_period,
       :period_amount_to_pay
     ].freeze
 
@@ -18,6 +20,7 @@ module LoanCreator
       end
 
       borrower_timetable = LoanCreator::Timetable.new(
+        starting_index: lenders_timetables.first.starting_index,
         starts_on: lenders_timetables.first.starts_on,
         period: lenders_timetables.first.period
       )

--- a/lib/loan_creator/timetable.rb
+++ b/lib/loan_creator/timetable.rb
@@ -9,7 +9,7 @@ module LoanCreator
       year:     {years: 1}
     }
 
-    attr_reader :terms, :starts_on, :period #, :interests_start_date
+    attr_reader :terms, :starts_on, :period, :starting_index #, :interests_start_date
 
     def initialize(starts_on:, period:, interests_start_date: nil, starting_index: 1)
       raise ArgumentError.new(:period) unless PERIODS.keys.include?(period)

--- a/lib/loan_creator/version.rb
+++ b/lib/loan_creator/version.rb
@@ -1,3 +1,3 @@
 module LoanCreator
-  VERSION = '0.7.0'.freeze
+  VERSION = '0.7.1'.freeze
 end

--- a/spec/loan_creator/borrower_spec.rb
+++ b/spec/loan_creator/borrower_spec.rb
@@ -74,7 +74,86 @@ describe LoanCreator::Common do
           attributes.each { |attr| expect(term.send(attr)).to eq(0) }
         end
       end
+    end
 
+    context "given starting index is not 1" do
+      let(:period) { :month }
+      let(:annual_interests_rate) { bigd('10') }
+      let(:starts_on) { Date.parse('2018-01-01') }
+      let(:duration_in_periods) { 36 }
+      let(:deferred_in_periods) { 0 }
+      let(:loan_commons) do
+        {
+          period: period,
+          annual_interests_rate: annual_interests_rate,
+          starts_on: starts_on,
+          duration_in_periods: duration_in_periods,
+          deferred_in_periods: deferred_in_periods,
+          initial_values: {
+            paid_capital: 0,
+            paid_interests: 0,
+            capitalized_interests: 0,
+            starting_index: 2,
+            accrued_delta_interests: 0
+          }
+        }
+      end
+      let(:loan_1) { LoanCreator::Standard.new(**loan_commons.merge({ amount: bigd('55000') })) }
+      let(:loan_2) { LoanCreator::Standard.new(**loan_commons.merge({ amount: bigd('21000') })) }
+      let(:loan_3) { LoanCreator::Standard.new(**loan_commons.merge({ amount: bigd('42000') })) }
+      let(:loans) { [loan_1, loan_2, loan_3] }
+      let(:lenders_timetables) { loans.map(&:lender_timetable) }
+      let(:borrower_timetable) { described_class.borrower_timetable(*lenders_timetables) }
+      let(:borrower_terms) { borrower_timetable.terms }
+      let(:lenders_terms) { lenders_timetables.map(&:terms) }
+      let(:transposed_lenders_terms) { lenders_terms.transpose }
+
+      it 'has valid period' do
+        expect(borrower_timetable.period).to eq(period)
+      end
+
+      it 'has valid start date' do
+        expect(borrower_timetable.starts_on).to eq(starts_on)
+      end
+
+      it 'has valid number of terms' do
+        expect(borrower_timetable.terms.count).to eq(duration_in_periods)
+      end
+
+      it 'has contiguous indexes' do
+        expect(borrower_timetable.terms.first.index).to eq(2)
+        index = 2
+        borrower_timetable.terms.each do |term|
+          expect(term.index).to eq(index)
+          index += 1
+        end
+      end
+
+      it 'has contiguous due_on dates' do
+        date = starts_on + 1.public_send(period)
+        expect(borrower_timetable.terms.first.due_on).to eq(date)
+        step = LoanCreator::Timetable::PERIODS.fetch(period)
+        borrower_timetable.terms.each do |term|
+          expect(term.due_on).to eq(date)
+          date = date.advance(step)
+        end
+      end
+
+      it 'has valid borrower-related values' do
+        borrower_timetable.terms.zip(transposed_lenders_terms).each do |term|
+          borrower_term, lenders_terms = term
+          LoanCreator::BorrowerTimetable::BORROWER_FINANCIAL_ATTRIBUTES.each do |attr|
+            expect(borrower_term.send(attr)).to eq(lenders_terms.sum(&attr))
+          end
+        end
+      end
+
+      it 'has non-borrower-related values set to zero' do
+        attributes = (LoanCreator::Term::ARGUMENTS - LoanCreator::BorrowerTimetable::BORROWER_FINANCIAL_ATTRIBUTES)
+        borrower_timetable.terms.each do |term|
+          attributes.each { |attr| expect(term.send(attr)).to eq(0) }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
La methode `borrower_timetable` qui fait la somme des `lender_timetables` ne prenait pas en compte le starting index ni les capitalized_interests